### PR TITLE
Add Mahithaa_Moganti to Contributors list

### DIFF
--- a/AWS/lambda_package/index_prisma.py
+++ b/AWS/lambda_package/index_prisma.py
@@ -49,7 +49,8 @@ runbook_lookup = {
     '7913fcbf-b679-5aac-d979-1b6817becb22' : 'AWS-SSS-014',
     '630d3779-d932-4fbf-9cce-6e8d793c6916' : 'PC-AWS-S3-29',
     '49f4760d-c951-40e4-bfe1-08acaa17672a' : 'AWS-VPC-020',
-    '11111111-1111-1111-1111-111111111111' : 'AWS-TEST-001'
+    '11111111-1111-1111-1111-111111111111' : 'AWS-TEST-001',
+    '3e631f04-e5f3-47e2-bb33-a213782494e0' : 'AWS-BUCK-001' #new remed
 }
 
 
@@ -74,8 +75,14 @@ def parse_alert_message(sqs_message):
         alert = json.loads(sqs_message)
 
         # Check for Prisma Cloud test notification
+        #this might be old one
         if alert['alertId'] == 'P-0':
             return {'error': "Prisma Cloud Test Notification", 'data': alert['alertId']}
+
+        # Check for Prisma Cloud test notification
+        #Latest test notification alert id
+        if alert['alertId'] == "T-0":
+            return {'error': None, 'data': alert['alertId']}    
             
         # Only remediate AWS
         #if alert['cloudType'] != 'aws':
@@ -149,6 +156,10 @@ def lambda_handler(event, context):
 
         if parsed_alert['data'] == 'P-0':
             print(parsed_alert['error'])
+        #processing the test notification message so that it doesnot stay in SQS Queue(Message in flight) and error out each and every time
+        #This is definitely important or else the message stays in the queue forever and lambda will throw errors each and every time the message is consumed
+        elif parsed_alert['data'] == 'T-0':
+            print('Prisma test Notification processed sucessfully')    
         else:
             
             if parsed_alert['error'] is not None:

--- a/AWS/lambda_package/runbooks/AWS-BUCK-001.py
+++ b/AWS/lambda_package/runbooks/AWS-BUCK-001.py
@@ -1,0 +1,164 @@
+"""
+Remediate Prisma Policy:
+PC-AWS-S3-322  AWS S3 bucket not configured with secure data transport policy
+Description:
+This policy identifies S3 buckets which are not configured with secure data transport policy. 
+It is recommended to add a bucket policy that explicitly denies (Effect: Deny) all access (Action: s3:*) from anybody who browses (Principal: *) to Amazon S3 objects within an Amazon S3 bucket if they are not accessed through HTTPS (aws:SecureTransport: false).
+Required permissions:
+- s3:PutBucketPolicy
+- s3:GetBucketPolicy
+Sample IAM Policy:
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt1507759700000",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutBucketPolicy",
+        "s3:GetBucketPolicy"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+
+"""
+
+import boto3
+import json
+from botocore.exceptions import ClientError
+
+
+def remediate(session, alert, lambda_context):
+  
+    bucket_name  = alert['resource_id']
+    region = alert['region']
+    
+    s3_client = session.client('s3', region_name=region)
+    
+
+    
+    try: 
+        result = s3_bucket_ssl_requests_only(bucket_name,s3_client)
+    except ClientError as e:
+        print(e.response['Error']['Message'])
+    except Exception as e:
+        raise Exception( "Unexpected error" + e.__str__())    
+        return
+  
+
+
+def s3_bucket_ssl_requests_only(bucket_name,s3_client):
+    
+    """Adds Bucket Policy to force SSL only connections
+    """
+        
+    #defining bucket policy
+    bucket_policy = {
+              "Id": "ForceSSLOnlyAccess",
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AllowSSLRequestsOnly",
+                  "Action": "s3:*",
+                  "Effect": "Deny",
+                  "Resource": [
+                    "arn:aws:s3:::"+bucket_name,
+                    "arn:aws:s3:::"+bucket_name+"/*"
+                  ],
+                  "Condition": {
+                    "Bool": {
+                      "aws:SecureTransport": "false"
+                    }
+                  },
+                  "Principal": "*"
+                }
+              ]
+        }
+    # Convert the policy to a JSON string
+    bucket_policy = json.dumps(bucket_policy)
+
+    # get existing bucket policy
+    response = s3_client.get_bucket_policy(Bucket=bucket_name)
+        
+    #if any bucket policy exists then append the new policy to the old policy
+    if (response):
+        bucket_policy_new={
+              "Sid": "AllowSSLRequestsOnly",
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Resource": [
+                "arn:aws:s3:::"+bucket_name,
+                "arn:aws:s3:::"+bucket_name+"/*"
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false"
+                }
+              },
+              "Principal": "*"
+            }
+            
+            
+        existing_policy = response['Policy']
+        ex_policy=json.loads(existing_policy)
+        sub_ex_policy = ex_policy['Statement']
+        sub_ex_policy.append(bucket_policy_new)
+        ex_policy['Statement']=sub_ex_policy
+        print(ex_policy)
+        print(' There is a existing Policy, have updated the policy')
+         # Convert the policy to a JSON string
+        bucket_policy = json.dumps(ex_policy)
+        
+        
+    try:
+        response = s3_client.put_bucket_policy(Bucket=bucket_name, Policy=bucket_policy)
+        print('Successful')
+    except:
+        set_bucket_policy(bucket_name,bucket_policy,s3_client)
+            
+            
+def set_bucket_policy(bucket_name,bucket_policy,s3_client):
+   
+    """Attempts to set an S3 Bucket Policy. If returned error is Access Denied, 
+    then the Public Access Block is removed before placing a new S3 Bucket Policy
+    
+    Arguments:
+        bucket {string} -- S3 Bucket Name
+        policy {string} -- S3 Bucket Policy
+    
+    Returns:
+        boolean -- True if S3 Bucket Policy was set
+    """
+    try:
+        # disable Public Access Block
+        s3_client.put_public_access_block(
+                Bucket=bucket_name,
+                PublicAccessBlockConfiguration={
+                    "BlockPublicPolicy": False,
+                    "RestrictPublicBuckets": False,
+                    },
+            )
+        print('Here one')
+        # put Bucket Policy
+        s3_client.put_bucket_policy(Bucket=bucket_name, Policy=bucket_policy)
+                # enable Public Access Block
+        print('Here two')        
+        s3_client.put_public_access_block(
+                Bucket=bucket_name,
+                PublicAccessBlockConfiguration={
+                    "BlockPublicPolicy": True,
+                    "RestrictPublicBuckets": True,
+                },
+            )
+        print('Here three')    
+    except:
+        print("Could not set SSL requests only policy to S3 Bucket")                
+       
+        
+        
+       
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,11 @@ of making a fork and pull request yourself:
 > 5. Create a pull request to pull the changes from your fork back into the
 >    upstream repository
 
+## Added Remediation for PC-AWS-S3-322  AWS S3 bucket not configured with secure data transport policy
+
+## Adding changes to index.py as the test notifications from Prisma to AWS is coming with alert id as "T-0"
+
+
 Please use clear commit messages so we can understand what each commit does.
 We'll review every PR and might offer feedback or request changes before
 merging.


### PR DESCRIPTION
## Description

There are two changes that have been made
1. Addition of New Remediation RunBook. This is created for the following Prisma Policy:
(PC-AWS-S3-322)  AWS S3 bucket not configured with secure data transport policy
What does the remediation perform: 
a. If an S3 bucket is in an alert state and the bucket does not contain any policy, a new bucket policy that explicitly denies (Effect: Deny) all access (Action: s3:) from anybody who browses (Principal: ) to Amazon S3 objects within an Amazon S3 bucket if they are not accessed through HTTPS (aws:SecureTransport: false)
b. If there is any existing bucket policy, it updates the policy with the secure transport policy
c.  **Note: This step is not necessary here but still added this as AWS Config rules find buckets that are not public. Sometimes a and b steps can fail if Public Access Block is enabled. Hence the Public Access Block is removed before placing a new S3 Bucket Policy and the Public Access Block is enabled at last

2. Changes are made to index.py. This is because when an SQS is integrated with Prisma the test notification alert id that it is sending is "T-0". Hence rather than throwing an error a step to process the test notification is added. Processing the test notification message so that it does not stay in SQS Queue(Message in flight) and error out each and every time. This is definitely important or else the message stays in the queue forever and lambda will throw errors each and every time the message is consumed 

## Motivation and Context

This feature improves the Prisma auto-remediation scope and adds more runbooks available for remediation. This will definitely help a lot of AWS Customers automate their AWS environment without having to manually add a policy manually to each and every S3 bucket


## How Has This Been Tested?

I have my own personal AWS Account and have tested this within this account. I have a Prisma Instance and have integrated with the same. I have created some s3 buckets with public access and a custom Prisma policy and added the policy id in the index.py file to invoke the respective runbook and once Prisma has shown up this is an alert after some time SQS queue got triggered with the findings. The runbook is then executed to add a new bucket policy or modify any existing bucket policy. Finally, after a few minutes, Prisma alerts have been resolved as the bucket is remediated. 
Testing Environment : 
a. Publicly accessible bucket with no bucket policy 
b. Publicly accessible bucket with existing bucket policy 




## Types of changes

<!--- What types of changes does your code introduce? -->

<!---A Bug fix to index.py function for Prisma Test Notification and New feature for remediation with runbook to a prisma policy (AWS S3 bucket not configured with secure data transport policy)  -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
